### PR TITLE
STEP10-Finalize 

### DIFF
--- a/.github/ConcurrencyTest.md
+++ b/.github/ConcurrencyTest.md
@@ -1,0 +1,193 @@
+# 유저 포인트 충전 기능(낙관적 락)
+
+
+
+## 포인트 충전에서 락이 필요한 이유
+
+- 여러 트랜잭션이 동시에 접근해 **중복 충전, 값 덮어쓰기** 같은 문제가 발생할 수 있음
+
+```
+트랜잭션 1: 포인트 조회 (1000)
+트랜잭션 2: 포인트 조회 (1000)
+트랜잭션 1: +1000 → 저장 (2000)
+트랜잭션 2: +1000 → 저장 (2000)
+->  충전 시도 금액 2000 ,실제 충전금액 1000 (중복 충전 누락)
+```
+
+- 위와 같은 상황을 방지하려면 동시성 제어가 필요하고, 그 수단으로 **낙관적 락(Optimistic Lock)** 적용
+
+---
+
+## 포인트 충전은 "자원 선점"이 아니다
+
+- 포인트 충전은 좌석 예약처럼 **희소한 자원을 여러 사용자가 경쟁하는 상황이 아님**
+- 같은 유저에 대해 여러 요청이 동시 들어오더라도 **각 요청이 독립적으로 수행될 수 있음**
+- **동시에 성공해도 상관없음**  
+  → 단, 충돌은 발생할 수 있으므로 **정합성을 위한 최소한의 동시성 제어는 필요**
+
+---
+
+## 충돌은 가능하지만, 발생 확률과 비용이 낮음
+
+- 같은 유저에 대해 동시에 포인트를 변경하는 경우는 상대적으로 **드문 상황**(따닥, 정도)
+- 충돌이 발생하더라도 낙관적 락은 **version 체크로 간단함**
+- 포인트 충전은 `+=` 단순 연산 → 이전 상태에 덧셈만 하는 구조이기 떄문에 재시도 로직 쉬움, 롤백시 DB 관점에서도 비교적 부담이 크지 않을 것으로 예상
+
+--> **포인트 충전은 희소 자원의 선점이 아니기 때문에, 충돌 발생 가능성이 낮고 재시도 로직으로 충분히 대응 가능하여 낙관적 락(Optimistic Lock)이 적합."**
+
+
+
+
+# 예약 선점 기능 (비관적 락)
+
+## 예약 선점 기능에서 락이 필요한 이유
+
+- 좌석 예약은 **자원 선점 경쟁** -> 하나의 좌석에 대해 동시에 여러 사용자가 접근 가능.
+- 락을 적용하지 않은 환경에서는 **중복 예약 또는 데이터 정합성 오류**가 발생 가능.
+- 따라서 **"좌석 1개당 1개의 예약만 허용"**해야 하며, 이를 보장하려면 **동시성 제어** 필요.
+- 즉, 트랜잭션 단위에서 **Row-Level Lock**을 걸어 **선점 성공자만 저장**.
+
+---
+
+## 낙관적 락이 아닌 비관적 락을 선택한 이유
+
+###경합이 매우 높은 상황
+- 티켓팅은 다수의 사용자가 동시에 특정 좌석을 선점하려는 상황으로 **경합이 극심**.
+- **낙관적 락은 충돌이 드물다는 전제에서 효과적**이지만, 이와 같은 시나리오에서는 **매 요청마다 충돌 가능성이 높음**.
+
+###낙관적 락의 구조적 한계
+- 낙관적 락은 트랜잭션 커밋 시점에 `@Version` 필드를 통해 충돌을 감지.
+- 충돌 시점이 **트랜잭션의 끝부분**이기 때문에, 그 이전에 수행된 작업들이 롤백처리
+- 이는  DB입장에서  **Undo Log, 락 해제, 트랜잭션 정리 등** 추가적인 비용 발생
+-  **재시도 로직**을 구성시, **부하 증가**
+   ###비관적 락의 실용적 장점
+- 비관적 락은 `SELECT ... FOR UPDATE`를 통해 **트랜잭션 초반에 row-level 락을 선점**한다.
+- **락을 선점하지 못한 요청은 대기** -> 대기시간(timeout)을 설정하여 즉시 실패 처리 가능**
+- **경쟁자가 많을수록 실패 요청을 빠르게 차단할 수 있음**
+  -트랜잭션이 **순차 처리**되기 때문에 **처리량이 감소**할 수 있으나, **데이터 정합성은 철저히 보장**
+---
+
+-> 결론 :  **"하나의 좌석에 단 하나의 예약만 허용해야 하며, 경합이 강한 기능이므로, 데이터 정합성과 시스템 안정성을 보장하기 위해 비관적 락(Pessimistic Lock)을 선택."**
+
+---
+## 트랜잭션 분리 전/ 후 K6 테스트
+
+| 항목                       | 분리 전 (트랜잭션 전체) | 분리 후 (Seat만 분리) | 비고 |
+|----------------------------|--------------------------|------------------------|------|
+| 요청 수                    | 100,000                  | 100,000                | 동일한 부하 조건 |
+| 성공 응답 (HTTP 200)      | 1건 (0.00%)              | 1건 (0.00%)            | - |
+| 실패 응답                 | 99,999건                 | 99,999건               | - |
+| 실패율                    | 99.99%                   | 99.99%                 | - |
+| 평균 응답 시간            | 0.268s                   | 0.860s                 | 락 대기 증가로 느려짐 |
+| 성공 요청 응답 시간       | 4.54s                    | 5.86s                  | 락 획득 대기 시간 증가 |
+| 평균 시나리오 실행 시간   | 8.85s                    | 11.78s                 | 평균 실행 시간 증가 |
+| 최대 시나리오 실행 시간   | 17.46s                   | 23.94s                 | 최악의 대기 시간 증가 |
+| 처리 속도 (req/s)         | 5,588 req/s              | 4,147 req/s            | 락 경합 증가로 감소 |
+
+---
+
+## 트랜잭션 구조 변화에 따른 영향 분석
+
+### 분리 전
+- Seat 조회부터 Reservation 저장까지 **하나의 트랜잭션 내에서 실행**됨
+- 락이 오래 유지되어 **경합은 줄지만 병렬성은 낮음**
+- **다른 요청은 아예 락 대기 상태에서 실패가 처리**됨
+
+### 분리 후
+- `seatHoldService.holdSeat()`만 분리하여 트랜잭션
+- Seat에 대한 락은 빨리 풀리지만, 다른 쓰레드로 바로 진입하여 **더 많은 요청이 락 경합에 진입함**
+- 이미 상태가 HOLDING이기 때문에 **실패는 그대로**, 단지 **경합과 부하만 증가**
+- 처리 시간, 평균 응답 시간, 최대 시간 모두 악화
+
+---
+
+## 5. 결론 및 인사이트
+
+- 단순히 트랜잭션을 분리한다고 성능이 항상 개선되진 않음
+- **락이 빨리 풀리는 구조에서는 경쟁자 수가 늘어나면서 실패 요청도 많아지고, 시스템 전체 응답 시간이 길어짐**
+- **앞 단에서의 대기열/예약열 구조로 경합 정도의 자체를 줄여야함**
+
+---
+
+
+<details>
+<summary>트랜잭션 전체 적용 구조</summary>
+
+<br>
+
+```java
+@Transactional
+@Override
+public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
+    User user = userRepository.findUserById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    Seat seat = seatRepository.findSeatById(reservationRequest.seatId())
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석입니다."));
+
+    if (!seat.isAvailable()) {
+        throw new IllegalStateException("이미 예약 중인 좌석입니다.");
+    }
+
+    seat.hold();
+    seatRepository.save(seat);
+
+    ConcertDate concertDate = concertRepository.findConcertDateById(reservationRequest.concertDateId())
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 날짜입니다."));
+
+    Reservation reservation = Reservation.holding(user, concertDate, seat);
+    reservationRepository.save(reservation);
+
+    return new ReservationResponse(
+        reservation.getId(),
+        reservationRequest.seatId(),
+        reservation.getStatus().name()
+    );
+}
+```
+
+</details>
+
+<details>
+<summary>트랜잭션 분리 구조</summary>
+
+<br>
+
+```java
+@Override
+public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
+    User user = userRepository.findUserById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    Seat seat = seatHoldService.holdSeat(reservationRequest.seatId());
+
+    ConcertDate concertDate = concertRepository.findConcertDateById(reservationRequest.concertDateId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 날짜입니다."));
+
+    Reservation reservation = Reservation.holding(user, concertDate, seat);
+    reservationRepository.save(reservation);
+
+    return new ReservationResponse(
+            reservation.getId(),
+            reservationRequest.seatId(),
+            reservation.getStatus().name()
+    );
+}
+
+@Transactional
+public Seat holdSeat(Long seatId) {
+    Seat seat = seatRepository.findSeatById(seatId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석입니다."));
+
+    if (!seat.isAvailable()) {
+        throw new IllegalStateException("이미 예약 중인 좌석입니다.");
+    }
+
+    seat.hold();
+    seatRepository.save(seat);
+
+    return seat;
+}
+```
+
+</details>

--- a/src/k6Test/reservation_k6_test.js
+++ b/src/k6Test/reservation_k6_test.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  vus: 100000,
+  iterations: 100000,
+};
+
+export default function () {
+  const userId = __ITER + 1;
+
+  const reservationPayload = JSON.stringify({
+    userId: userId,
+    concertDateId: 1,
+    seatId: 1
+  });
+
+  const res = http.post('http://localhost:8080/reservation', reservationPayload, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+}

--- a/src/main/java/kr/hhplus/be/server/concert/infra/persistence/SeatJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/concert/infra/persistence/SeatJpaRepository.java
@@ -1,15 +1,24 @@
 package kr.hhplus.be.server.concert.infra.persistence;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.concert.domain.Seat;
 import kr.hhplus.be.server.concert.domain.SeatStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Seat s WHERE s.id = :id")
+    Optional<Seat> findByIdForUpdate(@Param("id") Long id);
 
     List<Seat> findByConcertDateIdAndStatus(Long concertDateId, SeatStatus status);
     List<Seat> findByStatusAndExpireTimeBefore(SeatStatus status, LocalDateTime time);

--- a/src/main/java/kr/hhplus/be/server/concert/infra/persistence/SeatRepositoryAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/concert/infra/persistence/SeatRepositoryAdapter.java
@@ -19,7 +19,7 @@ public class SeatRepositoryAdapter implements  SeatRepository{
 
     @Override
     public Optional<Seat> findSeatById(Long id) {
-        return seatJpaRepository.findById(id);
+        return seatJpaRepository.findByIdForUpdate(id);
     }
 
     @Override

--- a/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
@@ -30,12 +30,31 @@ public class ReservationService implements ReservationUseCase {
     @Override
     public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
         User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다." + userId));
+
+        Seat seat = seatHoldService.holdSeat(reservationRequest.seatId());
+
+        ConcertDate concertDate = concertRepository.findConcertDateById(reservationRequest.concertDateId()) //콘서트 날짜 ID 로 conertDate 조회
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 날짜입니다."));
+
+        Reservation reservation = Reservation.holding(user,concertDate,seat);
+        reservationRepository.save(reservation);
+
+        return new ReservationResponse(reservation.getId(), reservationRequest.seatId(), reservation.getStatus().name()) ;
+    }
+}
+
+/*
+ @Transactional
+ @Override
+    public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
+        User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         Seat seat = seatRepository.findSeatById(reservationRequest.seatId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석입니다."));
 
         if(!seat.isAvailable()){ //좌석 상태 Available 인지 확인
             throw new IllegalStateException("이미 예약 중인 좌석입니다.");
         }
-        seat = seatHoldService.holdSeat(reservationRequest.seatId());
+        seat.hold(); //좌석 상태 Available -> Holding
+        seatRepository.save(seat);
 
         ConcertDate concertDate = concertRepository.findConcertDateById(reservationRequest.concertDateId()) //콘서트 날짜 ID 로 conertDate 조회
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 날짜입니다."));
@@ -48,5 +67,4 @@ public class ReservationService implements ReservationUseCase {
 
 
 
-    }
-}
+    }*/

--- a/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
@@ -14,6 +14,7 @@ import kr.hhplus.be.server.user.domain.User;
 import kr.hhplus.be.server.user.port.out.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class ReservationService implements ReservationUseCase {
     private final ConcertRepository concertRepository;
     private final SeatRepository seatRepository;
 
-
+    @Transactional
     @Override
     public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
         User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));

--- a/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/ReservationService.java
@@ -24,18 +24,18 @@ public class ReservationService implements ReservationUseCase {
     private final ReservationRepository reservationRepository;
     private final ConcertRepository concertRepository;
     private final SeatRepository seatRepository;
+    private final SeatHoldService seatHoldService;
 
-    @Transactional
+
     @Override
     public ReservationResponse reserve(ReservationRequest reservationRequest, Long userId) {
-        User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다." + userId));
         Seat seat = seatRepository.findSeatById(reservationRequest.seatId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석입니다."));
 
         if(!seat.isAvailable()){ //좌석 상태 Available 인지 확인
             throw new IllegalStateException("이미 예약 중인 좌석입니다.");
         }
-        seat.hold(); //좌석 상태 Available -> Holding
-        seatRepository.save(seat);
+        seat = seatHoldService.holdSeat(reservationRequest.seatId());
 
         ConcertDate concertDate = concertRepository.findConcertDateById(reservationRequest.concertDateId()) //콘서트 날짜 ID 로 conertDate 조회
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 날짜입니다."));

--- a/src/main/java/kr/hhplus/be/server/reservation/application/SeatHoldService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/SeatHoldService.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.reservation.application;
+
+import kr.hhplus.be.server.concert.domain.Seat;
+import kr.hhplus.be.server.concert.port.out.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SeatHoldService {
+
+    private final SeatRepository seatRepository;
+
+    @Transactional
+    public Seat holdSeat(Long seatId) {
+        Seat seat = seatRepository.findSeatById(seatId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좌석입니다."));
+
+        if (!seat.isAvailable()) {
+            throw new IllegalStateException("이미 예약 중인 좌석입니다.");
+        }
+
+        seat.hold();       // 상태 변경
+        seatRepository.save(seat); // 업데이트 반영
+
+        return seat;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/user/application/UserService.java
+++ b/src/main/java/kr/hhplus/be/server/user/application/UserService.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.user.application;
 
+import jakarta.transaction.Transactional;
 import kr.hhplus.be.server.user.domain.User;
 import kr.hhplus.be.server.user.port.in.UserUseCase;
 import kr.hhplus.be.server.user.port.out.UserRepository;
@@ -14,6 +15,7 @@ public class UserService implements UserUseCase {
 
     private final UserRepository userRepository;
 
+    @Transactional
     @Override
     public void chargePoint(Long userId, Long amount) {
         User user = userRepository.findUserById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));

--- a/src/main/java/kr/hhplus/be/server/user/domain/User.java
+++ b/src/main/java/kr/hhplus/be/server/user/domain/User.java
@@ -1,9 +1,6 @@
 package kr.hhplus.be.server.user.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import kr.hhplus.be.server.common.base.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +17,9 @@ public class User extends BaseTimeEntity {
     private Long id;
     private Long point;
 
+    @Version
+    private Long version;
+
 
     //UserRepositoryAdapter 테스트용
     public User(long userId, long point) {
@@ -29,6 +29,10 @@ public class User extends BaseTimeEntity {
 
     public User(Object o, String s, long l) {
         super();
+    }
+
+    public User(long point) {
+        this.point = point;
     }
 
 

--- a/src/main/java/kr/hhplus/be/server/user/domain/User.java
+++ b/src/main/java/kr/hhplus/be/server/user/domain/User.java
@@ -27,7 +27,9 @@ public class User extends BaseTimeEntity {
         this.point = point;
     }
 
-
+    public User(Object o, String s, long l) {
+        super();
+    }
 
 
     public void chargePoint(long amount){

--- a/src/test/java/kr/hhplus/be/server/payment/adpter/PaymentIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/payment/adpter/PaymentIntegrationTest.java
@@ -69,7 +69,7 @@ public class PaymentIntegrationTest {
         reservationJpaRepository.deleteAll();
         userJpaRepository.deleteAll();
 
-        var user = userJpaRepository.save(new User(null, 5000L));
+        var user = userJpaRepository.save(new User(1L, 5000L));
         var reservation = reservationJpaRepository.save(new Reservation(
                 null,
                 user,

--- a/src/test/java/kr/hhplus/be/server/reservation/adapter/ReservationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/reservation/adapter/ReservationIntegrationTest.java
@@ -75,7 +75,7 @@ public class ReservationIntegrationTest {
         concertJpaRepository.deleteAll();
         userJpaRepository.deleteAll();
 
-        User user = new User(null, 10000L);
+        User user = new User(1l, 10000L);
         user = userJpaRepository.save(user);
         savedUserId = user.getId();
 

--- a/src/test/java/kr/hhplus/be/server/reservation/application/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/reservation/application/ReservationConcurrencyTest.java
@@ -118,6 +118,7 @@ public class ReservationConcurrencyTest {
         assertThat(allReservations.get(0).getSeat().getId()).isEqualTo(seatId);
     }
 
+
     @Test
     void 동시에_100명이_동일한_좌석을_예약하면_1명만_성공한다() throws InterruptedException {
         int threadCount = 100;
@@ -133,7 +134,9 @@ public class ReservationConcurrencyTest {
             userIds.add(user.getId());
         }
 
-        // 동시에 예약 요청
+
+        long start = System.currentTimeMillis();
+
         for (Long userId : userIds) {
             executor.submit(() -> {
                 try {
@@ -150,20 +153,25 @@ public class ReservationConcurrencyTest {
             });
         }
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(500, TimeUnit.MILLISECONDS);  // 넉넉하게 대기
         executor.shutdown();
+
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+
+        System.out.println("소요 시간 (ms): " + duration);
 
         long successCount = results.stream().filter(r -> r.equals("SUCCESS")).count();
         long failCount = results.stream().filter(r -> r.startsWith("FAIL")).count();
 
-        System.out.println("SUCCESS: " + successCount + ", FAIL: " + failCount);
+        System.out.println("SUCCESS: " + successCount + ",FAIL: " + failCount);
 
         assertEquals(1, successCount);
-        assertEquals(99, failCount);
+        assertEquals(threadCount - 1, failCount);
 
         List<Reservation> allReservations = reservationJpaRepository.findAll();
         assertThat(allReservations).hasSize(1);
-        assertThat(allReservations.get(0).getSeat().getId()).isEqualTo(seatId);
     }
+
 
 }

--- a/src/test/java/kr/hhplus/be/server/reservation/application/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/reservation/application/ReservationConcurrencyTest.java
@@ -1,0 +1,169 @@
+package kr.hhplus.be.server.reservation.application;
+
+import kr.hhplus.be.server.concert.domain.ConcertDate;
+import kr.hhplus.be.server.concert.domain.Seat;
+import kr.hhplus.be.server.concert.domain.SeatStatus;
+import kr.hhplus.be.server.concert.infra.persistence.SeatJpaRepository;
+import kr.hhplus.be.server.concert.infra.persistence.ConcertDateJpaRepository;
+import kr.hhplus.be.server.reservation.domain.Reservation;
+import kr.hhplus.be.server.reservation.infra.persistence.ReservationJpaRepository;
+import kr.hhplus.be.server.reservation.infra.web.dto.ReservationRequest;
+import kr.hhplus.be.server.user.domain.User;
+import kr.hhplus.be.server.user.infra.persistence.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@SpringBootTest
+public class ReservationConcurrencyTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("test-db")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+    }
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private SeatJpaRepository seatJpaRepository;
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+    @Autowired
+    private ConcertDateJpaRepository concertDateJpaRepository;
+    @Autowired
+    private ReservationJpaRepository reservationJpaRepository;
+
+    private Long seatId;
+    private Long concertDateId;
+    private List<Long> userIds;
+
+    @BeforeEach
+    void setUp() {
+        reservationJpaRepository.deleteAll();
+
+        Seat seat = new Seat(null, 10, SeatStatus.AVAILABLE, null);
+        seatJpaRepository.save(seat);
+        seatId = seat.getId();
+
+        ConcertDate concertDate = new ConcertDate(null, null, LocalDate.now().plusDays(1));
+        concertDateJpaRepository.save(concertDate);
+        concertDateId = concertDate.getId();
+
+        userIds = List.of(
+                userJpaRepository.save(new User(null, "user1", 10000L)).getId(),
+                userJpaRepository.save(new User(null, "user2", 10000L)).getId(),
+                userJpaRepository.save(new User(null, "user3", 10000L)).getId()
+        );
+    }
+
+    @Test
+    void 동시에_여러명이_동일한_좌석을_예약하면_1명만_성공한다() throws InterruptedException {
+        int threadCount = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        ConcurrentLinkedQueue<String> results = new ConcurrentLinkedQueue<>();
+
+        for (Long userId : userIds) {
+            executor.submit(() -> {
+                try {
+                    reservationService.reserve(
+                            new ReservationRequest(userId,concertDateId, seatId),
+                            userId
+                    );
+                    results.add("SUCCESS");
+                } catch (Exception e) {
+                    results.add("FAIL" + e.getClass().getSimpleName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        long successCount = results.stream().filter(r -> r.equals("SUCCESS")).count();
+        long failCount = results.stream().filter(r -> r.startsWith("FAIL")).count();
+
+        assertEquals(1, successCount);
+        assertEquals(2, failCount);
+
+        List<Reservation> allReservations = reservationJpaRepository.findAll();
+        assertThat(allReservations).hasSize(1);
+        assertThat(allReservations.get(0).getSeat().getId()).isEqualTo(seatId);
+    }
+
+    @Test
+    void 동시에_100명이_동일한_좌석을_예약하면_1명만_성공한다() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentLinkedQueue<String> results = new ConcurrentLinkedQueue<>();
+
+
+        userIds = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            User user = new User(null, "user" + i, 10000L);
+            userJpaRepository.save(user);
+            userIds.add(user.getId());
+        }
+
+        // 동시에 예약 요청
+        for (Long userId : userIds) {
+            executor.submit(() -> {
+                try {
+                    reservationService.reserve(
+                            new ReservationRequest(userId, concertDateId, seatId),
+                            userId
+                    );
+                    results.add("SUCCESS");
+                } catch (Exception e) {
+                    results.add("FAIL: " + e.getClass().getSimpleName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        long successCount = results.stream().filter(r -> r.equals("SUCCESS")).count();
+        long failCount = results.stream().filter(r -> r.startsWith("FAIL")).count();
+
+        System.out.println("SUCCESS: " + successCount + ", FAIL: " + failCount);
+
+        assertEquals(1, successCount);
+        assertEquals(99, failCount);
+
+        List<Reservation> allReservations = reservationJpaRepository.findAll();
+        assertThat(allReservations).hasSize(1);
+        assertThat(allReservations.get(0).getSeat().getId()).isEqualTo(seatId);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/user/adapter/UserConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/user/adapter/UserConcurrencyTest.java
@@ -1,0 +1,95 @@
+package kr.hhplus.be.server.user.adapter;
+
+import kr.hhplus.be.server.user.domain.User;
+import kr.hhplus.be.server.user.infra.persistence.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class UserConcurrencyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Container
+    public static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @DynamicPropertySource
+    static void mysqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+    }
+
+
+    private Long savedUserId;
+
+    @BeforeEach
+    void setUp() {
+        userJpaRepository.deleteAll();
+
+        User user = new User();
+
+        user = userJpaRepository.save(new User(1000L));
+        savedUserId = user.getId();
+    }
+
+    @Test
+    void 동시에_포인트_충전시_낙관적락_충돌_발생() throws Exception {
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        String json = "{\"amount\":500}";
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.execute(() -> {
+                try {
+                    mockMvc.perform(post("/users/" + savedUserId + "/charge")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(json))
+                            .andExpect(status().isOk());
+                } catch (Exception e) {
+                    System.out.println("충돌 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        User user = userJpaRepository.findById(savedUserId).orElseThrow();
+        System.out.println("최종 포인트: " + user.getPoint());
+
+        assertThat(user.getPoint()).isEqualTo(1500L);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/user/adapter/UserIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/user/adapter/UserIntegrationTest.java
@@ -52,7 +52,7 @@ public class UserIntegrationTest {
 
         User user = new User();
 
-        user = userJpaRepository.save(new User(null, 1000L));
+        user = userJpaRepository.save(new User(1L, 1000L));
         savedUserId = user.getId();
     }
 


### PR DESCRIPTION
## :pushpin: PR 제목 규칙
STEP10-Finaliz concert

---

## :clipboard: 핵심 체크리스트 :white_check_mark:

### STEP10 - Finalize (1개)
- [x] **동시성 문제를 드러낼 수 있는 통합 테스트**를 작성했는가?
---

### 커밋 링크 
- 유저 포인트 충전(https://github.com/SONG-JAEHONG/HH_WEEK5/pull/1/commits/880d7fb38b11ce0428c11fdf786d9a57eaded8e2)
- 예약 요청 Lock 처리 (https://github.com/SONG-JAEHONG/HH_WEEK5/pull/1/commits/8434ce5aa55a26761cb145e19a8fdf8cc454f8a4)
- 예약 요청 통합테스트 (https://github.com/SONG-JAEHONG/HH_WEEK5/pull/1/commits/53e71293c268855a0cacabbd1f614f0510a3f209, https://github.com/SONG-JAEHONG/HH_WEEK5/pull/1/commits/9fa50c6cdd333696c9ead7b5037215738ff9d157)


### 리뷰 포인트(질문)
1. 실무에서 낙관적 락을 적용하신 예시가 있으실까요?

- 포인트 충전에 낙관적 락을 사용하긴 했지만, 사실 중복 충전이나, 값 덮어씌워지는 경우들의 문제는 클라이언트 단에서 충분히 방지가 가능하다고 생각합니다.

ex) 충전 하시겠습니까? (javascript - confirm) 에서 확인 버튼을 누르면 충전(두번 이상 누르고 싶어도 못 누르므로 중복 충전이나, 값 덮어쓰기 가능성 없다고 생각됨)

따라서 최소한의 방지라고 생각하며 포인트 충전에 적용하긴 했습니다.

실무에서는 낙관적 락을 어떤 경우에 사용하셨는지가 궁금합니다.


2. 트랜잭션을 분리해보았습니다.(제대로 했는지는 잘 모르겠습니다.)

- 트랜잭션을 작은 단위로 쪼개 보았습니다. 
원래는 reserve() 메소드 전체에 트랜잭션을 걸고 유저조회 , 좌석 조회, 좌석 상태 변경~ 예약 객체 생성 까지 했다면,
좌석 조회와 좌석 상태 변경를 다른 서비스로 분리하였습니다.

따라서 reservationService 에서 seatHoldService의 메소드를 사용하게 되었는데 ,  의존성 역전 법칙에 어긋나는 건가요?
(같은 계층이라 괜찮다고도 생각이 듭니다만 확인차.,.질문 드립니다)

또한 이렇게 서비스를 분리를 하면 파일 위치를 어디에 위치시켜야 할까요?

현재는 reservation - application -reservationService, seatHoldService 같이 두고 있습니다.

뭔가 reservationService 는 비즈니스 로직 서비스이고, seatHoldService는 비즈니스 로직이라고 보기엔 애매한 서비스 같아 질문드립니다.

seat 패키지를 따로 만들어서 거기에 위치 시켜야 할까요?.




## ✍️ 간단 회고 (3줄 이내)
- **잘한 점**: DB 락 관련 유튜브 강의를 하나 잘 찾아서 이해에 도움이 된것 같다.
- **어려웠던 점**:  낙관적 락 / 비관적 락 적용 기준이 아직도 약간 애매한 부분이 있다.
- **다음 시도**:  트랜잭션에 대해서 더 공부를 해야겠다